### PR TITLE
using system umu instead of managing it in game-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "game-rs"
-version = "0.2.0"
+version = "4.0.0"
 dependencies = [
  "clap",
  "confy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "game-rs"
-version = "0.2.0"
+version = "4.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # A minimal (cli) Game launcher for linux written in rust
 
+<sub><sup>this program uses [ZenVer](https://github.com/NotAShelf/ZenVer) from z3 and above</sup></sub>
+
 [![Rust](https://github.com/Amanse/game-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/Amanse/game-rs/actions/workflows/rust.yml)
 
 ## Prerequisite

--- a/README.md
+++ b/README.md
@@ -2,14 +2,26 @@
 
 [![Rust](https://github.com/Amanse/game-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/Amanse/game-rs/actions/workflows/rust.yml)
 
+## Prerequisite
+
+You need to have [umu-launcher](https://github.com/Open-Wine-Components/umu-launcher) installed, it used to be managed by game-rs but it needs it's installation steps now, it is pre installed for the nix version.
+
 ## Install
+
+### Arch linux
+
+Install AUR packages
+[game-rs](https://aur.archlinux.org/packages/game-rs-bin) (Thankyou proledatarian. very cool) & [umu-launcher](https://aur.archlinux.org/packages/umu-launcher)
+
+### Other distros
+
 `cargo install --path .`
-or use [AUR](https://aur.archlinux.org/packages/game-rs-bin) (Thankyou proledatarian. very cool)
-### for nixos
-#### Without flakes
-`cargo install --features nixos --path .` to compile and install manually  
-#### With flakes
+and you can find your way of installing umu-launcher [here](https://github.com/Open-Wine-Components/umu-launcher/releases)
+
+### For Nixos
+
 You can do `nix run` to run it or you can add it as a package in your configuration
+
 ```nix
 #flake.nix
 {
@@ -18,7 +30,9 @@ You can do `nix run` to run it or you can add it as a package in your configurat
   };
 }
 ```
+
 and then you can add it in your packages with
+
 ```nix
 {
   environment.systemPackages = with pkgs; [
@@ -26,8 +40,10 @@ and then you can add it in your packages with
   ];
 }
 ```
+
 You can also use [Cachix](https://game-rs.cachix.org) to get binary cache <br />
 To add cachix:
+
 ```nix
 {
   nix.settings = {
@@ -36,11 +52,13 @@ To add cachix:
   };
 }
 ```
+
 cachix works with both adding as a package and just doing `nix build` or `nix run`
 
 ## Usage
+
 `game-rs config` to go into interactive config mode where you can add, edit or delete the games in config <br />
 `game-rs run` to get a fuzzy select menu of all the games in config, selecting it runs the game <br />
 `game-rs run <id>` to directly run the game with specified id <br />
+`game-rs run -v` to run in verbose mode
 `game-rs download --help` to see what you can download manually, but you will probably not need this
-

--- a/flake.lock
+++ b/flake.lock
@@ -58,7 +58,8 @@
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "umu": "umu"
       }
     },
     "systems": {
@@ -74,6 +75,30 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
+      }
+    },
+    "umu": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "dir": "packaging/nix",
+        "lastModified": 1714290028,
+        "narHash": "sha256-yCgf0jPlCjVMhQfw0gC5Q+FvDq/y68BELVOYHDHCKVA=",
+        "ref": "refs/heads/main",
+        "rev": "2d855719dd768dcbed388e0650ae0b76ed154e9b",
+        "revCount": 480,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging/nix"
+      },
+      "original": {
+        "dir": "packaging/nix",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging/nix"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,11 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     crane.url = "github:ipetkov/crane";
     crane.inputs.nixpkgs.follows = "nixpkgs";
+
+    umu = {
+      url = "git+https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging\/nix&submodules=1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
@@ -12,6 +17,7 @@
     flake-utils,
     nixpkgs,
     crane,
+    umu,
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
@@ -27,6 +33,8 @@
           src = craneLib.cleanCargoSource (craneLib.path ./.);
           cargoExtraArgs = "--features nixos";
 
+          propagatedBuildInputs = [umu.packages.${pkgs.system}.umu];
+
           # Add extra inputs here or any other derivation settings
           # doCheck = true;
           # buildInputs = [];
@@ -35,7 +43,7 @@
 
         # For `nix develop`:
         devShell = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [cargo rustc rustfmt rust-analyzer clippy];
+          nativeBuildInputs = with pkgs; [cargo rustc rustfmt rust-analyzer clippy umu.packages.${pkgs.system}.umu python3];
           shellHook = ''
             export PATH="$PATH:/home/me/.cargo/bin"
           '';

--- a/src/config/config2.rs
+++ b/src/config/config2.rs
@@ -47,8 +47,7 @@ impl Config {
             .with_prompt("Select game")
             .items(&self.games.clone())
             .interact_opt()
-            .unwrap()
-            .unwrap();
+            .unwrap()?;
 
         Ok(self.games[sel].clone())
     }

--- a/src/config/config2.rs
+++ b/src/config/config2.rs
@@ -47,7 +47,8 @@ impl Config {
             .with_prompt("Select game")
             .items(&self.games.clone())
             .interact_opt()
-            .unwrap()?;
+            .unwrap()
+            .unwrap();
 
         Ok(self.games[sel].clone())
     }

--- a/src/config/extra.rs
+++ b/src/config/extra.rs
@@ -106,29 +106,4 @@ impl ExtraConfig {
 #[cfg(test)]
 mod tests {
     use std::fs;
-
-    #[test]
-    fn test_proton_finder() {
-        let parent = "/tmp/parent";
-        fs::create_dir(parent).unwrap();
-        let prots: Vec<&str> = vec!["Proton-30", "Proton-32"];
-        let mut want: Vec<String> = vec![];
-
-        for prot in prots {
-            let dir = format!("{}/{}", parent, prot);
-            fs::create_dir(dir.clone()).unwrap();
-            fs::File::create(format!("{}/proton", dir.clone())).unwrap();
-            want.push(dir);
-        }
-
-        let mut runners: Vec<String> = vec![];
-
-        super::ExtraConfig::get_runners_for(parent.to_string(), &mut runners).unwrap();
-
-        fs::remove_dir_all(parent).unwrap();
-
-        println!("{:?}", runners);
-        want.reverse();
-        assert_eq!(want, runners);
-    }
 }

--- a/src/config/game.rs
+++ b/src/config/game.rs
@@ -1,6 +1,9 @@
 use eyre::Result;
 use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, process::Command};
+use std::{
+    collections::HashMap,
+    process::{Command, Stdio},
+};
 
 use super::{
     extra::ExtraConfig,
@@ -107,9 +110,9 @@ impl Game {
         self
     }
 
-    pub fn run(mut self) -> Result<Game> {
+    pub fn run(mut self, is_verbose: bool) -> Result<Game> {
         let mut cmd = self.gen_cmd()?;
-        self.run_cmd(&mut cmd)
+        self.run_cmd(&mut cmd, is_verbose)
     }
 
     fn gen_cmd(&self) -> Result<Command> {
@@ -144,11 +147,17 @@ impl Game {
         Ok(cmd)
     }
 
-    fn run_cmd(&mut self, cmd: &mut Command) -> Result<Game> {
+    fn run_cmd(&mut self, cmd: &mut Command, is_verbose: bool) -> Result<Game> {
         //Execute the command and return Game object with updated runtime
 
         let start = std::time::Instant::now();
-        cmd.output().unwrap();
+
+        if is_verbose {
+            cmd.status().unwrap();
+        } else {
+            cmd.output().unwrap();
+        }
+
         let played = start.elapsed().as_secs();
         self.playtime += played;
         Ok(self.clone())

--- a/src/config/game.rs
+++ b/src/config/game.rs
@@ -1,9 +1,6 @@
 use eyre::Result;
 use serde_derive::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    process::{Command, Stdio},
-};
+use std::{collections::HashMap, process::Command};
 
 use super::{
     extra::ExtraConfig,
@@ -122,7 +119,7 @@ impl Game {
         let mut cmd = Command::new("sh");
 
         if !self.is_native {
-            cmd.arg(format!("umu"));
+            cmd.arg("umu");
         }
 
         cmd.arg(self.exect_path.clone());
@@ -162,10 +159,6 @@ impl Game {
         self.playtime += played;
         Ok(self.clone())
     }
-}
-
-fn get_ulwgl_path() -> String {
-    format!("{}/.local/share/ULWGL", std::env::var("HOME").unwrap())
 }
 
 #[cfg(test)]

--- a/src/config/game.rs
+++ b/src/config/game.rs
@@ -119,10 +119,7 @@ impl Game {
         let mut cmd = Command::new("sh");
 
         if !self.is_native {
-            #[cfg(feature = "nixos")]
-            cmd.arg("steam-run");
-
-            cmd.arg(format!("{}/ulwgl-run", get_ulwgl_path()));
+            cmd.arg(format!("umu"));
         }
 
         cmd.arg(self.exect_path.clone());
@@ -169,10 +166,7 @@ mod tests {
     use super::Game;
 
     fn get_ulwgl_exec_path() -> String {
-        format!(
-            "{}/.local/share/ULWGL/ulwgl-run",
-            std::env::var("HOME").unwrap()
-        )
+        format!("umu")
     }
 
     fn get_game() -> Game {
@@ -219,10 +213,7 @@ mod tests {
         let args: Vec<&OsStr> = cmd.get_args().collect();
 
         #[cfg(feature = "nixos")]
-        assert_eq!(
-            args,
-            &["steam-run", &get_ulwgl_exec_path(), "/home/me/exec"]
-        );
+        assert_eq!(args, &[&get_ulwgl_exec_path(), "/home/me/exec"]);
 
         #[cfg(not(feature = "nixos"))]
         assert_eq!(args, &[&get_ulwgl_exec_path(), "/home/me/exec"]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,9 @@ fn main() -> Result<(), eyre::Report> {
 
     let mut con2 = Config::new()?;
     match &cli.command {
-        Command::Run(_r_param) => {
+        Command::Run(r_param) => {
             let g = con2.game_selector()?;
-            let game = g.run()?;
+            let game = g.run(r_param.verbose)?;
             con2.update_with_id(game);
 
             Ok(())


### PR DESCRIPTION
umu is getting packaged for distros, It is available for nixos as a flake and is available on AUR as well, using umu provided by system will help eliminate steam-run unfree dependency on the nixos version and also reduce maintenance work on the downloader.  
Changes need to be done:
- [x] use system umu to run games
- [x] Remove code that used manually downloaded umu
- [ ] Remove download module for umu
- [x] move binary name of umu to a variable (Confirm if binary name is different on different distros)
- [x] update readme since nixpkgs game-rs cannot use umu

Will need to wait for the official nixpkgs to get UMU and then the fully unfree package can be merged into nixpkgs